### PR TITLE
[fix] #1 paths broken on Windows

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -12,7 +12,7 @@ export class JspmAssetStream extends Duplex {
     private package: string = '';
     private glob: string = '';
     private started: boolean = false;
-    private fileExt: RegExp = /file:\/\//i;
+    private protocolRE: RegExp = /^file:\/{2,4}/i;
     private _jspm: Jspm;
 
     constructor(options: { package: string, glob: string }) {
@@ -27,10 +27,7 @@ export class JspmAssetStream extends Duplex {
     }
 
     private cleanFilePath(filePath: string): string {
-        if (filePath.search(this.fileExt) !== -1) {
-            filePath = filePath.substring(6, filePath.length);
-        }
-        return filePath;
+        return filePath.replace(this.protocolRE, '');
     }
 
     private resolveDirectory(packageName: string): Promise<string> {


### PR DESCRIPTION
Fixes issue #1 
It would seem that the 'file' protocol takes 2 forward slashes in Linux (`file://`) and 4 in Windows (`file:////`). So I adjusted the regex to account for that.
